### PR TITLE
Expose show-stdout

### DIFF
--- a/.github/actions/go-test/action.yml
+++ b/.github/actions/go-test/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'Arguments to pass to `go test`'
     required: false
     default: -race;-tags=testing netgo
+  show-stdout:
+    description: "Show unparsed stdout from `go test`"
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -18,3 +22,4 @@ runs:
       uses: n8maninger/action-golang-test@v2
       with:
         args: ${{ inputs.go-test-args }}
+        show-stdout: "${{ inputs.show-stdout }}"

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -3,6 +3,11 @@ name: Lint & Test Go
 on:
   workflow_call:
     inputs:
+      show-stdout:
+        description: "Show unparsed stdout from `go test`"
+        type: string
+        required: false
+        default: "false"
       go-test-args:
         description: "Arguments to pass to `go test`"
         type: string
@@ -32,6 +37,7 @@ jobs:
       - uses: SiaFoundation/workflows/.github/actions/go-test@master
         with:
           go-test-args: ${{ inputs.go-test-args }}
+          show-stdout: "${{ inputs.show-stdout }}"
       - name: Build
         if: ${{ inputs.try-build }}
         shell: bash


### PR DESCRIPTION
Exposing this input is useful for debugging purposes, e.g. dumping a stack-trace to stdout is not possible without this flag. There's alternatives, such as writing to a file and uploading it as an artefact which I learned about today but nevertheless I feel we should expose this flag as it'll prove useful in the future. 