### PR TITLE
publish openapi remove name input

### DIFF
--- a/.github/workflows/publish-openapi.yml
+++ b/.github/workflows/publish-openapi.yml
@@ -3,10 +3,6 @@ name: Publish OpenAPI to Scalar Registry
 on:
   workflow_call:
     inputs:
-      name:
-        description: Display name of the API being published.
-        required: true
-        type: string
       spec_path:
         description: Path to the OpenAPI spec file in the repo.
         required: true
@@ -31,7 +27,7 @@ on:
 
 jobs:
   publish:
-    name: Publish ${{ inputs.name }}
+    name: Publish ${{ inputs.slug }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -50,15 +46,15 @@ jobs:
           sudo chmod +x /usr/local/bin/yq
 
       # Bundle the OpenAPI spec to resolve external refs.
-      - name: Bundle OpenAPI (${{ inputs.name }})
+      - name: Bundle OpenAPI (${{ inputs.slug }})
         run: npx --yes @scalar/cli document bundle ${{ inputs.spec_path }} --output "$RUNNER_TEMP/bundle-${{ inputs.slug }}.yml"
 
       # Validate the bundled OpenAPI spec.
-      - name: Validate OpenAPI (Bundled ${{ inputs.name }})
+      - name: Validate OpenAPI (Bundled ${{ inputs.slug }})
         run: npx --yes @scalar/cli document validate "$RUNNER_TEMP/bundle-${{ inputs.slug }}.yml"
 
       # Extract version from info.version.
-      - name: Extract version (${{ inputs.name }})
+      - name: Extract version (${{ inputs.slug }})
         id: ver
         run: echo "version=$(yq -r '.info.version' ${{ inputs.spec_path }})" >> "$GITHUB_OUTPUT"
 
@@ -67,7 +63,7 @@ jobs:
         run: npx --yes @scalar/cli auth login --token ${{ secrets.SCALAR_API_KEY }}
 
       # Publish to Scalar Registry.
-      - name: Publish to Registry (${{ inputs.name }})
+      - name: Publish to Registry (${{ inputs.slug }})
         run: |
           npx --yes @scalar/cli registry publish "$RUNNER_TEMP/bundle-${{ inputs.slug }}.yml" \
             --namespace "${{ inputs.namespace }}" \


### PR DESCRIPTION
- This input was redundant as it was only used in GitHub action output. The actual name on our docs is determined by the title in the spec file.