### PR TITLE
pin scalar cli to latest version

### DIFF
--- a/.github/workflows/publish-openapi.yml
+++ b/.github/workflows/publish-openapi.yml
@@ -53,11 +53,11 @@ jobs:
 
       # Bundle the OpenAPI spec to resolve external refs.
       - name: Bundle OpenAPI (${{ inputs.slug }})
-        run: npx --yes @scalar/cli document bundle ${{ inputs.spec_path }} --output "$RUNNER_TEMP/bundle-${{ inputs.slug }}.yml"
+        run: npx --yes @scalar/cli@1.3.4 document bundle ${{ inputs.spec_path }} --output "$RUNNER_TEMP/bundle-${{ inputs.slug }}.yml"
 
       # Validate the bundled OpenAPI spec.
       - name: Validate OpenAPI (Bundled ${{ inputs.slug }})
-        run: npx --yes @scalar/cli document validate "$RUNNER_TEMP/bundle-${{ inputs.slug }}.yml"
+        run: npx --yes @scalar/cli@1.3.4 document validate "$RUNNER_TEMP/bundle-${{ inputs.slug }}.yml"
 
       # Extract version from info.version.
       - name: Extract version (${{ inputs.slug }})
@@ -66,12 +66,12 @@ jobs:
 
       # Authenticate with Scalar.
       - name: Login to Scalar
-        run: npx --yes @scalar/cli auth login --token ${{ secrets.SCALAR_API_KEY }}
+        run: npx --yes @scalar/cli@1.3.4 auth login --token ${{ secrets.SCALAR_API_KEY }}
 
       # Publish to Scalar Registry.
       - name: Publish to Registry (${{ inputs.slug }})
         run: |
-          npx --yes @scalar/cli registry publish "$RUNNER_TEMP/bundle-${{ inputs.slug }}.yml" \
+          npx --yes @scalar/cli@1.3.4 registry publish "$RUNNER_TEMP/bundle-${{ inputs.slug }}.yml" \
             --namespace "${{ inputs.namespace }}" \
             --slug "${{ inputs.slug }}" \
             --version "${{ steps.ver.outputs.version }}" \


### PR DESCRIPTION
- For some reason the workflow which uses npx is saying to upgrade, it must be cached, this should force it to use the latest version, after which we can see if there are any more errors.