### PR TITLE
Update Go to 1.25/1.26

### DIFF
--- a/.github/workflows/go-publish.yml
+++ b/.github/workflows/go-publish.yml
@@ -7,7 +7,7 @@ on:
         description: Set the Go version to use. It is not recommended to use this input.
         type: string
         required: false
-        default: "1.25"
+        default: "1.26"
       linux-build-args:
         description: Arguments to pass to `go build` for Linux
         type: string

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.24, 1.25]
+        go-version: [1.25, 1.26]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Update shared CI workflows to use Go 1.25 and 1.26 (from 1.24 and 1.25).

- `go-test.yml`: matrix updated to `[1.25, 1.26]`
- `go-publish.yml`: default go-version updated to `1.26`