### PR TITLE
ci: pin GitHub Actions to SHA-256 commits

### DIFF
--- a/.github/workflows/go-publish.yml
+++ b/.github/workflows/go-publish.yml
@@ -63,21 +63,21 @@ jobs:
       packages: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ inputs.go-version }}
       - name: Test
-        uses: SiaFoundation/workflows/.github/actions/go-test@master
+        uses: SiaFoundation/workflows/.github/actions/go-test@22e56c0750c0febb09784caa01c60021e0b5f111 # master
         with:
           go-test-args: ${{ inputs.go-test-args }}
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           cache-image: false
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
           cache-binary: false
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -87,7 +87,7 @@ jobs:
         run: |
           # Docker image tags require all lowercase
           echo "DOCKER_IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         name: generate tags
         id: meta
         with:
@@ -97,7 +97,7 @@ jobs:
             type=sha,prefix=
             type=semver,pattern={{version}}
             type=raw,value=latest-beta,enable=${{ startsWith(github.ref, 'refs/tags/') }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ${{ inputs.dockerfile }}
@@ -116,12 +116,12 @@ jobs:
     env:
       RELEASE_NAME: ${{ inputs.project }}_linux_${{ matrix.go-arch }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ inputs.go-version }}
       - name: Test
-        uses: SiaFoundation/workflows/.github/actions/go-test@master
+        uses: SiaFoundation/workflows/.github/actions/go-test@22e56c0750c0febb09784caa01c60021e0b5f111 # master
         with:
           go-test-args: ${{ inputs.go-test-args }}
       - name: Setup CGO
@@ -146,7 +146,7 @@ jobs:
           ZIP_OUTPUT=release/$RELEASE_NAME.zip
           cp README.md LICENSE bin/
           zip -qj $ZIP_OUTPUT bin/*
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.RELEASE_NAME}}
           path: release/*
@@ -160,12 +160,12 @@ jobs:
     env:
       RELEASE_NAME: ${{ inputs.project }}_darwin_${{ matrix.go-arch }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ inputs.go-version }}
       - name: Test
-        uses: SiaFoundation/workflows/.github/actions/go-test@master
+        uses: SiaFoundation/workflows/.github/actions/go-test@22e56c0750c0febb09784caa01c60021e0b5f111 # master
         with:
           go-test-args: ${{ inputs.go-test-args }}
       - name: Setup
@@ -232,7 +232,7 @@ jobs:
           ditto -ck bin $ZIP_OUTPUT
           # submit to notary service
           xcrun notarytool submit -k ~/private_keys/AuthKey_$APPLE_API_KEY.p8 -d $APPLE_API_KEY -i $APPLE_API_ISSUER --wait --timeout 10m $ZIP_OUTPUT
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.RELEASE_NAME}}
           path: release/*
@@ -249,15 +249,15 @@ jobs:
       - name: Configure Git # required for golangci-lint on Windows
         shell: bash
         run: git config --global core.autocrlf false
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ inputs.go-version }}
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: "10"
       - name: Test
-        uses: SiaFoundation/workflows/.github/actions/go-test@master
+        uses: SiaFoundation/workflows/.github/actions/go-test@22e56c0750c0febb09784caa01c60021e0b5f111 # master
         with:
           go-test-args: ${{ inputs.go-test-args }}
       - name: Setup
@@ -287,7 +287,7 @@ jobs:
           ZIP_OUTPUT=release/$RELEASE_NAME.zip
           cp README.md LICENSE bin/
           7z a $ZIP_OUTPUT ./bin/*
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.RELEASE_NAME}}
           path: release/*
@@ -296,7 +296,7 @@ jobs:
     needs: [linux, macos, windows]
     steps:
       - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ inputs.project }}
   homebrew: # only runs when version-tag is a stable release tag (doesn't contain '-')
@@ -305,7 +305,7 @@ jobs:
     runs-on: tenki-standard-small-2c-4g
     steps:
       - name: Dispatch
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.PAT_REPOSITORY_DISPATCH }}
           repository: siafoundation/homebrew-sia

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -27,11 +27,11 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         shell: bash
         run: git config --global core.autocrlf false
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ matrix.go-version }}
-      - uses: SiaFoundation/workflows/.github/actions/go-test@master
+      - uses: SiaFoundation/workflows/.github/actions/go-test@22e56c0750c0febb09784caa01c60021e0b5f111 # master
         with:
           go-test-args: ${{ inputs.go-test-args }}
       - name: Build

--- a/.github/workflows/project-add.yml
+++ b/.github/workflows/project-add.yml
@@ -9,7 +9,7 @@ jobs:
     name: Add issue to project
     runs-on: tenki-standard-small-2c-4g
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@1b844f0c5ac6446a402e0cb3693f9be5eca188c5 # v0.6.1
         with:
           # You can target a project in a different organization
           # to the issue

--- a/.github/workflows/publish-openapi.yml
+++ b/.github/workflows/publish-openapi.yml
@@ -36,11 +36,11 @@ jobs:
     name: Publish ${{ inputs.slug }}
     runs-on: tenki-standard-small-2c-4g
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ inputs.node_version }}
 

--- a/.github/workflows/sync-openapi-version.yml
+++ b/.github/workflows/sync-openapi-version.yml
@@ -20,7 +20,7 @@ jobs:
   sync:
     runs-on: tenki-standard-small-2c-4g
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -32,7 +32,7 @@ jobs:
 
       - name: Sync OpenAPI versions
         id: sync
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -117,7 +117,7 @@ jobs:
 
       - name: Create Pull Request
         if: ${{ steps.sync.outputs.changed == 'true' }}
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/sync-openapi-version-to-${{ steps.sync.outputs.version }}


### PR DESCRIPTION
## Summary
- Pin every `uses:` reference in workflows to a specific commit SHA
- Each pin is annotated with the corresponding version tag in a trailing comment
- Versions stay within the existing major (e.g. `@v4` → latest v4.x.y SHA) to avoid breaking changes

## Why
Mitigates supply-chain attacks where a tag could be retargeted to malicious code. Pinning to a SHA is the [recommended hardening practice](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

## Notes for reviewers
- Annotated tags resolve to the underlying commit SHA (not the tag object)
- For `SiaFoundation/workflows@master` and `dtolnay/rust-toolchain@stable|nightly` (which use a branch ref intentionally), the pin uses the current branch tip SHA — future updates will require a follow-up PR
- This PR was generated by tooling; please skim each workflow diff
